### PR TITLE
Fix ui to match design

### DIFF
--- a/docs/Foundational_skills/contact-section/css/style.css
+++ b/docs/Foundational_skills/contact-section/css/style.css
@@ -54,7 +54,6 @@ body {
 
 .contact-form-section.confirmed {
     align-items: center;
-    height: 398px;
     justify-content: center;
 }
 

--- a/docs/Foundational_skills/contact-section/index.html
+++ b/docs/Foundational_skills/contact-section/index.html
@@ -95,7 +95,7 @@
 
                 <!-- Contact form section -->
 
-                <div class="relative contact-form-section w-full  lg:w-[592px] flex flex-col gap-10 bg-white p-4 rounded-lg outline outline-1  outline-t-1 outline-l-1 outline-r-1 outline-b-1  outline-neutral-200 border-none md:p-8 md:border md:border-solid md:border-neutral-200 md:outline-none">
+                <div class="relative contact-form-section w-full h-[398px] lg:w-[592px] flex flex-col gap-10 bg-white p-4 rounded-lg outline outline-1  outline-t-1 outline-l-1 outline-r-1 outline-b-1  outline-neutral-200 border-none md:p-8 md:border md:border-solid md:border-neutral-200 md:outline-none">
                     <form class="flex flex-col gap-6 relative"
                           id="contact-form">
                         <div class="flex flex-col gap-6">


### PR DESCRIPTION
This pull request includes changes to the contact form section in the foundational skills documentation. The changes primarily focus on the layout and styling of the contact form section.

Layout and styling changes:

* [`docs/Foundational_skills/contact-section/css/style.css`](diffhunk://#diff-f61068e22df28f8dec8402ae2f79e6de690968be3a146f67a902687ce9e18abbL57): Removed the fixed height of 398px from the `.contact-form-section.confirmed` class to allow for more flexible height adjustments.
* [`docs/Foundational_skills/contact-section/index.html`](diffhunk://#diff-903aa21a4167fdb9abfa9122ffa2827bfdd96b70f87b7cc280b0eb5b910b13b0L98-R98): Added a fixed height of 398px to the `contact-form-section` div to maintain consistent height across different screen sizes.